### PR TITLE
fix: Add configuration schema to plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,33 @@ class Plugin {
         .then(this.compileFunctionDeadLetterResources)
 
     };
+
+    // Configuration Schema
+    // Author: Harrison Bowers
+    // Date: Thu 12 Jan 2023
+    // https://www.serverless.com/framework/docs/guides/plugins/custom-configuration
+    this.serverless.configSchemaHandler.defineFunctionProperties("aws", {
+      type: "object",
+      properties: {
+        deadLetter: {
+          type: "object",
+          required: ["sqs"],
+          additionalProperties: true,
+          properties: {
+            sqs: {
+              type: "object",
+              additionalProperties: true,
+              required: ["queueName"],
+              properties: {
+                queueName: { type: "string" },
+                messageRetentionPeriod: { type: "number" },
+                visibilityTimeout: { type: "number" },
+              },
+            },
+          },
+        },
+      },
+    });
   }
 
   resolveTargetArn(functionName, deadLetter, resolveStackResources) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,9 @@ class Plugin {
         .then(this.setLambdaDeadLetterConfig),
 
       'deploy:compileEvents': () => BbPromise.bind(this)
+        .then(this.compileFunctionDeadLetterResources),
+
+      'package:compileEvents': () => BbPromise.bind(this)
         .then(this.compileFunctionDeadLetterResources)
 
     };


### PR DESCRIPTION
Fix: Add the serverless configuration schema to the serverless-plugin-lambda-dead-letter plugin. 

**I dont believe this work is capable of being landed yet, as despite resolving schema issues the outcome of packaging appears to be the removal of all dead letter queues:**

![Screen Shot 2023-01-12 at 3 54 29 pm](https://user-images.githubusercontent.com/23712835/211979654-e5fd5c59-6a33-4b8b-aba5-631fcbf85094.png)


Following practice of [YAGNI](https://martinfowler.com/bliki/Yagni.html) the schema only covers the structure currently implemented within the `data-service` (Team to confirm that this is what is used across the board). 

Serverless V3 Before:
```
Running "serverless" from node_modules
Stager: environment is "dev"
Stager: environment is "dev"

Warning: Invalid configuration encountered
  at 'functions.bulkImportEventHandler': unrecognized property 'deadLetter'
  at 'functions.gmbTranslator': unrecognized property 'deadLetter'
  at 'functions.relationshipsEvents_listener': unrecognized property 'deadLetter'
  at 'functions.resourceLinkTracker_listener': unrecognized property 'deadLetter'
  at 'functions.uamSync_listener': unrecognized property 'deadLetter'

Learn more about configuration validation here: http://slss.io/configuration-validation
...
```

Serverless V3 After:
```
Running "serverless" from node_modules
Stager: environment is "dev"
Stager: environment is "dev"
...
```