### PR TITLE
fix: disable sqs property as required in validation and add targetArn…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class Plugin {
       properties: {
         deadLetter: {
           type: 'object',
-          required: ['sqs'],
+          required: [],
           additionalProperties: true,
           properties: {
             sqs: {
@@ -40,6 +40,9 @@ class Plugin {
                 messageRetentionPeriod: { type: 'number' },
                 visibilityTimeout: { type: 'number' }
               }
+            },
+            targetArn: {
+              type: 'string'
             }
           }
         }


### PR DESCRIPTION
Hello!

I'm a Software Developer at EasyB2B and i'm using this plugin to solve some questions about dead letter's and lambda functions in serverless.


In documentation, the sqs property is not defined as required in method 2 case for defining a existing dead letter, see link here: https://www.npmjs.com/package/serverless-plugin-lambda-dead-letter#method-2

Therefore, i made this commit to solve this issue, it's a quick change, thanks!